### PR TITLE
Add binary output cache for host exec calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +832,12 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1734,6 +1754,7 @@ name = "starship-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dashmap",
  "filetime",
  "mlua",
  "phf",
@@ -1745,6 +1766,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "wasmtime",
+ "which",
 ]
 
 [[package]]
@@ -2509,6 +2531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723f2473b47f738c12fc11c8e0bb8b27ce7cf9c78cf1a29dadbc2d34a2513292"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repo is meant to serve as a proof of concept for a new architecture for Sta
 - [ ] Budget: 16.67ms (60fps) or 8.33ms (120fps)
 - [x] Daemon responds to `nc` for other shell prompts to use:
       `echo '{"pwd":"'$PWD'","user":"'$USER'"}' | nc -U ~/.config/starship/starship.sock`
+- [x] Cache binary output keyed by resolved path, size, and mtime
 - [ ] Have modules enable based on repo root
 
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -14,10 +14,11 @@ use directories::UserDirs;
 use std::path::PathBuf;
 
 pub fn get_config_dir() -> Result<PathBuf> {
+    if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(xdg_config).join("starship"));
+    }
     let user_dirs = UserDirs::new().with_context(|| "Failed to get user directories")?;
-    let config_dir = user_dirs.home_dir().join(".config");
-    let starship_dir = config_dir.join("starship");
-    Ok(starship_dir)
+    Ok(user_dirs.home_dir().join(".config").join("starship"))
 }
 
 pub fn get_cache_dir() -> Result<PathBuf> {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -19,3 +19,11 @@ pub fn get_config_dir() -> Result<PathBuf> {
     let starship_dir = config_dir.join("starship");
     Ok(starship_dir)
 }
+
+pub fn get_cache_dir() -> Result<PathBuf> {
+    if let Ok(xdg_cache) = std::env::var("XDG_CACHE_HOME") {
+        return Ok(PathBuf::from(xdg_cache).join("starship"));
+    }
+    let user_dirs = UserDirs::new().with_context(|| "Failed to get user directories")?;
+    Ok(user_dirs.home_dir().join(".cache").join("starship"))
+}

--- a/crates/plugin-sdk/src/host.rs
+++ b/crates/plugin-sdk/src/host.rs
@@ -7,6 +7,7 @@ use crate::{read_msg, write_msg};
 unsafe extern "C" {
     fn _plugin_host_get_env(packed: u64) -> u64;
     fn _plugin_host_exec(packed: u64) -> u64;
+    fn _plugin_host_exec_uncached(packed: u64) -> u64;
     fn _plugin_host_file_exists(packed: u64) -> u32;
 }
 
@@ -32,6 +33,25 @@ pub fn exec(cmd: &str, args: &[&str]) -> Option<String> {
         let request = (cmd, args);
         let packed_input = write_msg(&request);
         let packed_output = unsafe { _plugin_host_exec(packed_input) };
+        unsafe { read_msg(packed_output) }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = (cmd, args);
+        panic!("host functions only available in WASM");
+    }
+}
+
+/// Execute the provided command without caching the result.
+///
+/// Use for commands whose output depends on state beyond the binary itself
+/// (e.g. `git branch`, `pwd`).
+pub fn exec_uncached(cmd: &str, args: &[&str]) -> Option<String> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let request = (cmd, args);
+        let packed_input = write_msg(&request);
+        let packed_output = unsafe { _plugin_host_exec_uncached(packed_input) };
         unsafe { read_msg(packed_output) }
     }
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -14,6 +14,8 @@ mlua = { version = "0.11", features = ["luau", "serde", "error-send"] }
 phf = "0.11"
 wasmtime = "43.0.0"
 starship-plugin-core = { version = "0.0.0", path = "../plugin-core" }
+which = "8.0.2"
+dashmap = "6.1.0"
 
 [features]
 testing = ["dep:tempfile"]

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -1,12 +1,14 @@
 use crate::config::nerd_font::register_icon_function;
 use crate::config::style::{register_compact_function, register_style_functions, LuaStyledContent};
+use crate::exec_cache::ExecCache;
 use crate::plugin::{load_plugins, register_plugin, WasmPlugin};
 use anyhow::Result;
 use mlua::{FromLua, Lua, LuaOptions, LuaSerdeExt, SerializeOptions, StdLib};
 use serde::{Deserialize, Serialize};
-use starship_common::{get_config_dir, styled::StyledContent, ShellContext};
+use starship_common::{get_cache_dir, get_config_dir, styled::StyledContent, ShellContext};
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::{fs, path::PathBuf, time::SystemTime};
 use tracing::instrument;
 use wasmtime::Engine;
@@ -69,7 +71,8 @@ impl ConfigLoader {
     pub fn from_path(path: impl Into<PathBuf>) -> Result<Self> {
         let plugin_dir = get_plugin_dir();
         let default_pwd = std::env::current_dir().unwrap_or_default();
-        let plugins = load_plugins(&Engine::default(), &plugin_dir, &default_pwd)
+        let exec_cache = Arc::new(create_exec_cache());
+        let plugins = load_plugins(&Engine::default(), &plugin_dir, &default_pwd, &exec_cache)
             .into_iter()
             .map(|p| Rc::new(RefCell::new(p)))
             .collect();
@@ -246,6 +249,16 @@ fn get_plugin_dir() -> PathBuf {
     }
 
     default_dir
+}
+
+fn create_exec_cache() -> ExecCache {
+    get_cache_dir().map_or_else(
+        |_| {
+            tracing::warn!("failed to resolve cache dir, exec cache will be in-memory only");
+            ExecCache::load(PathBuf::from("/dev/null"))
+        },
+        |dir| ExecCache::load(dir.join("exec_cache.json")),
+    )
 }
 
 fn has_wasm_files(dir: &std::path::Path) -> bool {
@@ -435,10 +448,7 @@ mod tests {
 
     #[test]
     fn stdlib_globals_resolve_through_env() {
-        assert_eq!(
-            render(r"return { format = tostring(math.max(1, 2)) }"),
-            "2",
-        );
+        assert_eq!(render(r"return { format = tostring(math.max(1, 2)) }"), "2",);
     }
 
     #[test]

--- a/crates/runtime/src/exec_cache.rs
+++ b/crates/runtime/src/exec_cache.rs
@@ -9,7 +9,7 @@
 //! `$XDG_CACHE_HOME/starship/exec_cache.json` immediately.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use dashmap::DashMap;
@@ -123,10 +123,14 @@ fn build_key(cmd: &str, args: &[String]) -> Option<ExecCacheKey> {
             return None;
         }
     };
-    let metadata = match fs::metadata(&binary_path) {
+    key_for_path(&binary_path, args)
+}
+
+fn key_for_path(binary_path: &Path, args: &[String]) -> Option<ExecCacheKey> {
+    let metadata = match fs::metadata(binary_path) {
         Ok(m) => m,
         Err(e) => {
-            tracing::warn!(cmd, path = %binary_path.display(), %e, "exec cache: stat failed");
+            tracing::warn!(path = %binary_path.display(), %e, "exec cache: stat failed");
             return None;
         }
     };
@@ -134,7 +138,7 @@ fn build_key(cmd: &str, args: &[String]) -> Option<ExecCacheKey> {
     let duration = mtime.duration_since(UNIX_EPOCH).ok()?;
     #[allow(clippy::cast_possible_truncation)]
     Some(ExecCacheKey {
-        binary_path,
+        binary_path: binary_path.to_path_buf(),
         binary_size: metadata.len(),
         mtime_nanos: duration.as_nanos() as u64,
         args: args.to_vec(),
@@ -169,6 +173,21 @@ mod tests {
         let cache = ExecCache::in_memory();
         let args = vec![];
         assert!(cache.get("this_binary_does_not_exist_xyz", &args).is_none());
+    }
+
+    #[test]
+    fn modified_binary_produces_different_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("bin");
+        fs::write(&file, "v1").unwrap();
+
+        let args = vec![];
+        let key1 = key_for_path(&file, &args).unwrap();
+
+        fs::write(&file, "v2 different size").unwrap();
+        let key2 = key_for_path(&file, &args).unwrap();
+
+        assert_ne!(key1, key2);
     }
 
     #[test]

--- a/crates/runtime/src/exec_cache.rs
+++ b/crates/runtime/src/exec_cache.rs
@@ -95,6 +95,7 @@ impl ExecCache {
     }
 
     /// Persist the full cache to disk as a JSON array of `[key, value]` pairs.
+    #[instrument(skip(self))]
     fn flush(&self) {
         let Some(path) = &self.cache_path else {
             return;

--- a/crates/runtime/src/exec_cache.rs
+++ b/crates/runtime/src/exec_cache.rs
@@ -116,8 +116,20 @@ impl ExecCache {
 /// Build a cache key by resolving the command to an absolute path and
 /// statting the binary for size and mtime.
 fn build_key(cmd: &str, args: &[String]) -> Option<ExecCacheKey> {
-    let binary_path = which::which(cmd).ok()?;
-    let metadata = fs::metadata(&binary_path).ok()?;
+    let binary_path = match which::which(cmd) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(cmd, %e, "exec cache: which lookup failed");
+            return None;
+        }
+    };
+    let metadata = match fs::metadata(&binary_path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(cmd, path = %binary_path.display(), %e, "exec cache: stat failed");
+            return None;
+        }
+    };
     let mtime = metadata.modified().ok()?;
     let duration = mtime.duration_since(UNIX_EPOCH).ok()?;
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/runtime/src/exec_cache.rs
+++ b/crates/runtime/src/exec_cache.rs
@@ -1,0 +1,180 @@
+//! Binary output cache for host exec calls.
+//!
+//! Caches command output keyed by the resolved binary's identity (absolute path,
+//! file size, mtime) and command arguments. This avoids re-executing commands
+//! like `node --version` on every prompt render when the underlying binary
+//! hasn't changed.
+//!
+//! The cache is write-through: every new entry is persisted to
+//! `$XDG_CACHE_HOME/starship/exec_cache.json` immediately.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::UNIX_EPOCH;
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+/// Cache key combining a binary's identity with its invocation arguments.
+///
+/// Binary updates (different size or mtime) naturally cause cache misses
+/// because the key no longer matches, which is what makes this safe to use
+/// with version managers that swap binaries in PATH.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+struct ExecCacheKey {
+    /// Absolute path to the resolved binary.
+    binary_path: PathBuf,
+    /// File size in bytes.
+    binary_size: u64,
+    /// Nanoseconds since `UNIX_EPOCH`.
+    mtime_nanos: u64,
+    /// Command arguments.
+    args: Vec<String>,
+}
+
+/// In-memory cache of binary exec results, backed by a JSON file on disk.
+///
+/// Uses `DashMap` for non-blocking concurrent reads. Writes are sharded
+/// internally so readers are never blocked.
+pub struct ExecCache {
+    entries: DashMap<ExecCacheKey, String>,
+    cache_path: Option<PathBuf>,
+}
+
+impl ExecCache {
+    /// Load cache from disk, or create empty if the file is missing or corrupt.
+    #[must_use]
+    pub fn load(cache_path: PathBuf) -> Self {
+        let entries = DashMap::new();
+        if let Some(pairs) = fs::read_to_string(&cache_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<Vec<(ExecCacheKey, String)>>(&s).ok())
+        {
+            for (k, v) in pairs {
+                entries.insert(k, v);
+            }
+        }
+        Self {
+            entries,
+            cache_path: Some(cache_path),
+        }
+    }
+
+    /// Create an in-memory-only cache with no disk persistence.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn in_memory() -> Self {
+        Self {
+            entries: DashMap::new(),
+            cache_path: None,
+        }
+    }
+
+    /// Look up a cached exec result.
+    ///
+    /// Resolves `cmd` to an absolute path via PATH, stats the binary for
+    /// size/mtime, and checks the cache. Returns `None` on cache miss or if
+    /// the binary can't be resolved/statted.
+    #[instrument(skip(self), fields(%cmd))]
+    pub fn get(&self, cmd: &str, args: &[String]) -> Option<String> {
+        let key = build_key(cmd, args)?;
+        self.entries.get(&key).map(|v| v.value().clone())
+    }
+
+    /// Insert a result and write-through to disk.
+    ///
+    /// No-op if the binary can't be resolved or statted (the result is
+    /// still returned to the caller, just not cached).
+    #[instrument(skip(self, output), fields(%cmd))]
+    pub fn insert(&self, cmd: &str, args: &[String], output: String) {
+        let Some(key) = build_key(cmd, args) else {
+            return;
+        };
+        self.entries.insert(key, output);
+        self.flush();
+    }
+
+    /// Persist the full cache to disk as a JSON array of `[key, value]` pairs.
+    fn flush(&self) {
+        let Some(path) = &self.cache_path else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let entries: Vec<_> = self
+            .entries
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        if let Ok(json) = serde_json::to_string(&entries) {
+            let _ = fs::write(path, json);
+        }
+    }
+}
+
+/// Build a cache key by resolving the command to an absolute path and
+/// statting the binary for size and mtime.
+fn build_key(cmd: &str, args: &[String]) -> Option<ExecCacheKey> {
+    let binary_path = which::which(cmd).ok()?;
+    let metadata = fs::metadata(&binary_path).ok()?;
+    let mtime = metadata.modified().ok()?;
+    let duration = mtime.duration_since(UNIX_EPOCH).ok()?;
+    #[allow(clippy::cast_possible_truncation)]
+    Some(ExecCacheKey {
+        binary_path,
+        binary_size: metadata.len(),
+        mtime_nanos: duration.as_nanos() as u64,
+        args: args.to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_miss_then_hit() {
+        let cache = ExecCache::in_memory();
+        // "echo" should be resolvable on any system
+        let args = vec!["hello".to_string()];
+        assert!(cache.get("echo", &args).is_none());
+        cache.insert("echo", &args, "hello\n".to_string());
+        assert_eq!(cache.get("echo", &args).as_deref(), Some("hello\n"));
+    }
+
+    #[test]
+    fn different_args_are_distinct() {
+        let cache = ExecCache::in_memory();
+        let args_a = vec!["a".to_string()];
+        let args_b = vec!["b".to_string()];
+        cache.insert("echo", &args_a, "a\n".to_string());
+        assert!(cache.get("echo", &args_b).is_none());
+    }
+
+    #[test]
+    fn unresolvable_command_returns_none() {
+        let cache = ExecCache::in_memory();
+        let args = vec![];
+        assert!(cache.get("this_binary_does_not_exist_xyz", &args).is_none());
+    }
+
+    #[test]
+    fn disk_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("exec_cache.json");
+        let args = vec!["--version".to_string()];
+
+        // Write
+        {
+            let cache = ExecCache::load(cache_path.clone());
+            cache.insert("echo", &args, "1.0\n".to_string());
+        }
+
+        // Read back
+        {
+            let cache = ExecCache::load(cache_path);
+            assert_eq!(cache.get("echo", &args).as_deref(), Some("1.0\n"));
+        }
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod config;
+pub mod exec_cache;
 pub mod plugin;
 
 pub use config::{Config, ConfigLoader};
+pub use exec_cache::ExecCache;

--- a/crates/runtime/src/plugin.rs
+++ b/crates/runtime/src/plugin.rs
@@ -97,8 +97,7 @@ fn host_exec(caller: &mut Caller<'_, HostState>, packed: u64) -> Result<u64> {
     let (cmd, args): (String, Vec<String>) = serde_json::from_slice(&bytes)?;
     let _span = tracing::info_span!("host_exec", %cmd).entered();
 
-    let cache = Arc::clone(&caller.data().exec_cache);
-    if let Some(cached) = cache.get(&cmd, &args) {
+    if let Some(cached) = caller.data().exec_cache.get(&cmd, &args) {
         tracing::debug!("cache hit");
         let result: Option<String> = Some(cached);
         let json = serde_json::to_vec(&result)?;
@@ -108,7 +107,7 @@ fn host_exec(caller: &mut Caller<'_, HostState>, packed: u64) -> Result<u64> {
     let result = run_command(&cmd, &args, &caller.data().pwd);
 
     if let Some(ref output) = result {
-        cache.insert(&cmd, &args, output.clone());
+        caller.data().exec_cache.insert(&cmd, &args, output.clone());
     }
 
     let json = serde_json::to_vec(&result)?;

--- a/crates/runtime/src/plugin.rs
+++ b/crates/runtime/src/plugin.rs
@@ -1,6 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use mlua::{Lua, LuaSerdeExt, Table};
@@ -9,8 +10,11 @@ use starship_plugin_core::{from_bitwise, into_bitwise};
 use tracing::instrument;
 use wasmtime::{Caller, Engine, Linker, Memory, Module, Store, TypedFunc};
 
+use crate::exec_cache::ExecCache;
+
 struct HostState {
     pwd: PathBuf,
+    exec_cache: Arc<ExecCache>,
 }
 
 struct GuestExports {
@@ -92,16 +96,43 @@ fn host_exec(caller: &mut Caller<'_, HostState>, packed: u64) -> Result<u64> {
     caller_dealloc(caller, packed)?;
     let (cmd, args): (String, Vec<String>) = serde_json::from_slice(&bytes)?;
     let _span = tracing::info_span!("host_exec", %cmd).entered();
-    let output = std::process::Command::new(&cmd)
-        .args(&args)
-        .current_dir(&caller.data().pwd)
-        .output();
-    let result: Option<String> = output
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).to_string());
+
+    let cache = Arc::clone(&caller.data().exec_cache);
+    if let Some(cached) = cache.get(&cmd, &args) {
+        tracing::debug!("cache hit");
+        let result: Option<String> = Some(cached);
+        let json = serde_json::to_vec(&result)?;
+        return write_guest_bytes(caller, &json);
+    }
+
+    let result = run_command(&cmd, &args, &caller.data().pwd);
+
+    if let Some(ref output) = result {
+        cache.insert(&cmd, &args, output.clone());
+    }
+
     let json = serde_json::to_vec(&result)?;
     write_guest_bytes(caller, &json)
+}
+
+fn host_exec_uncached(caller: &mut Caller<'_, HostState>, packed: u64) -> Result<u64> {
+    let bytes = read_guest_bytes(caller, packed)?;
+    caller_dealloc(caller, packed)?;
+    let (cmd, args): (String, Vec<String>) = serde_json::from_slice(&bytes)?;
+    let _span = tracing::info_span!("host_exec_uncached", %cmd).entered();
+    let result = run_command(&cmd, &args, &caller.data().pwd);
+    let json = serde_json::to_vec(&result)?;
+    write_guest_bytes(caller, &json)
+}
+
+fn run_command(cmd: &str, args: &[String], pwd: &Path) -> Option<String> {
+    std::process::Command::new(cmd)
+        .args(args)
+        .current_dir(pwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
 }
 
 #[instrument(skip_all)]
@@ -134,6 +165,15 @@ fn create_linker(engine: &Engine) -> Result<Linker<HostState>> {
 
     linker.func_wrap(
         "env",
+        "_plugin_host_exec_uncached",
+        |mut caller: Caller<'_, HostState>, packed: u64| -> wasmtime::Result<u64> {
+            host_exec_uncached(&mut caller, packed)
+                .map_err(|err| wasmtime::Error::msg(err.to_string()))
+        },
+    )?;
+
+    linker.func_wrap(
+        "env",
         "_plugin_host_file_exists",
         |mut caller: Caller<'_, HostState>, packed: u64| -> wasmtime::Result<u32> {
             host_file_exists(&mut caller, packed)
@@ -147,22 +187,29 @@ fn create_linker(engine: &Engine) -> Result<Linker<HostState>> {
 impl WasmPlugin {
     /// Loads a WASM plugin by compiling bytes and instantiating the module.
     ///
-    /// Links host functions (`get_env`, `exec`, `file_exists`), instantiates the module,
-    /// reads the plugin name, and creates a guest-side instance handle.
-    pub fn load(engine: &Engine, wasm_bytes: &[u8], pwd: &Path) -> Result<Self> {
+    /// Links host functions (`get_env`, `exec`, `exec_uncached`, `file_exists`),
+    /// instantiates the module, reads the plugin name, and creates a guest-side
+    /// instance handle.
+    pub fn load(
+        engine: &Engine,
+        wasm_bytes: &[u8],
+        pwd: &Path,
+        exec_cache: Arc<ExecCache>,
+    ) -> Result<Self> {
         let module = tracing::info_span!("compile").in_scope(|| Module::new(engine, wasm_bytes))?;
-        Self::from_module(&module, pwd)
+        Self::from_module(&module, pwd, exec_cache)
     }
 
     /// Creates a plugin instance from a pre-compiled module, skipping WASM
     /// compilation. Use when instantiating the same plugin multiple times.
-    pub fn from_module(module: &Module, pwd: &Path) -> Result<Self> {
+    pub fn from_module(module: &Module, pwd: &Path, exec_cache: Arc<ExecCache>) -> Result<Self> {
         let engine = module.engine();
         let linker = create_linker(engine)?;
         let mut store = Store::new(
             engine,
             HostState {
                 pwd: pwd.to_path_buf(),
+                exec_cache,
             },
         );
         let instance = tracing::info_span!("instantiate")
@@ -341,8 +388,13 @@ pub fn register_plugin(lua: &Lua, plugin: Rc<RefCell<WasmPlugin>>) -> mlua::Resu
 /// Returns an empty vec if the directory doesn't exist. Logs and skips
 /// individual plugins that fail to load.
 #[must_use]
-#[instrument(skip(engine, pwd))]
-pub fn load_plugins(engine: &Engine, plugin_dir: &Path, pwd: &Path) -> Vec<WasmPlugin> {
+#[instrument(skip(engine, pwd, exec_cache))]
+pub fn load_plugins(
+    engine: &Engine,
+    plugin_dir: &Path,
+    pwd: &Path,
+    exec_cache: &Arc<ExecCache>,
+) -> Vec<WasmPlugin> {
     if !plugin_dir.exists() {
         return vec![];
     }
@@ -360,7 +412,7 @@ pub fn load_plugins(engine: &Engine, plugin_dir: &Path, pwd: &Path) -> Vec<WasmP
                 plugin = %path.file_stem().unwrap_or_default().to_string_lossy(),
             )
             .entered();
-            match WasmPlugin::load(engine, &bytes, pwd) {
+            match WasmPlugin::load(engine, &bytes, pwd, Arc::clone(exec_cache)) {
                 Ok(plugin) => Some(plugin),
                 Err(err) => {
                     tracing::error!("Failed to load plugin {}: {}", path.display(), err);
@@ -374,10 +426,12 @@ pub fn load_plugins(engine: &Engine, plugin_dir: &Path, pwd: &Path) -> Vec<WasmP
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use wasmtime::{Engine, Module};
 
     use super::WasmPlugin;
+    use crate::exec_cache::ExecCache;
 
     pub const TEST_HARNESS_WASM: &[u8] = include_bytes!(concat!(
         env!("WASM_PLUGIN_DIR"),
@@ -404,7 +458,9 @@ pub mod test_helpers {
             let path = dir.path().to_path_buf();
             let engine = Engine::default();
             let module = Module::new(&engine, bytes).expect("plugin should compile");
-            let plugin = WasmPlugin::from_module(&module, &path).expect("plugin should load");
+            let cache = Arc::new(ExecCache::in_memory());
+            let plugin =
+                WasmPlugin::from_module(&module, &path, cache).expect("plugin should load");
             Self {
                 dir: path,
                 plugin,
@@ -450,7 +506,8 @@ pub mod test_helpers {
         }
 
         fn plugin_for_loader(&self) -> WasmPlugin {
-            WasmPlugin::from_module(&self.module, &self.dir).expect("plugin should load")
+            let cache = Arc::new(ExecCache::in_memory());
+            WasmPlugin::from_module(&self.module, &self.dir, cache).expect("plugin should load")
         }
     }
 
@@ -467,11 +524,13 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::Arc;
 
     use mlua::{Lua, LuaOptions, StdLib};
     use wasmtime::Engine;
 
     use super::load_plugins;
+    use crate::exec_cache::ExecCache;
     use crate::plugin_fixture;
 
     #[test]
@@ -511,7 +570,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let plugin_dir = tempfile::tempdir().expect("plugin dir");
         let engine = Engine::default();
-        let plugins = load_plugins(&engine, plugin_dir.path(), dir.path());
+        let cache = Arc::new(ExecCache::in_memory());
+        let plugins = load_plugins(&engine, plugin_dir.path(), dir.path(), &cache);
         assert!(plugins.is_empty());
     }
 


### PR DESCRIPTION
Cache command output keyed by resolved binary identity (absolute path,
file size, mtime) and arguments. Uses DashMap for non-blocking concurrent
reads with write-through persistence to $XDG_CACHE_HOME/starship/exec_cache.json.

Plugins use host::exec() for cached calls and host::exec_uncached() for
state-dependent commands like git.Cache command output keyed by resolved binary identity (absolute path,
file size, mtime) and arguments. Uses DashMap for non-blocking concurrent
reads with write-through persistence to $XDG_CACHE_HOME/starship/exec_cache.json.

Plugins use host::exec() for cached calls and host::exec_uncached() for
state-dependent commands like git.