### PR TITLE
perf: enable wasmtime disk-backed compilation cache

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -15,7 +15,7 @@ starship-common = { workspace = true }
 starship-daemon = { workspace = true }
 starship-runtime = { workspace = true, features = ["testing"] }
 tempfile = "3.27.0"
-wasmtime = "43.0.0"
+wasmtime = { version = "43.0.0", features = ["cache"] }
 
 [[bench]]
 name = "starship_bench"

--- a/benches/benches/starship_bench.rs
+++ b/benches/benches/starship_bench.rs
@@ -3,7 +3,7 @@ use divan::{black_box, Bencher};
 use starship_common::ShellContext;
 use starship_daemon::handle_client;
 use starship_runtime::plugin::test_helpers::{PluginFixture, TEST_HARNESS_WASM};
-use starship_runtime::plugin::WasmPlugin;
+use starship_runtime::plugin::{self, WasmPlugin};
 use starship_runtime::{ConfigLoader, ExecCache};
 use std::{os::unix::net::UnixStream, path::PathBuf, sync::Arc};
 
@@ -86,7 +86,7 @@ fn cached_config(bencher: Bencher, config: &BenchConfig) {
 
 #[divan::bench]
 fn plugin_load() {
-    let engine = wasmtime::Engine::default();
+    let engine = plugin::create_engine().unwrap();
     let dir = tempfile::tempdir().unwrap();
     black_box(
         WasmPlugin::load(

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 starship-common = { workspace = true }
 mlua = { version = "0.11", features = ["luau", "serde", "error-send"] }
 phf = "0.11"
-wasmtime = "43.0.0"
+wasmtime = { version = "43.0.0", features = ["cache"] }
 starship-plugin-core = { version = "0.0.0", path = "../plugin-core" }
 which = "8.0.2"
 dashmap = "6.1.0"

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -1,7 +1,7 @@
 use crate::config::nerd_font::register_icon_function;
 use crate::config::style::{register_compact_function, register_style_functions, LuaStyledContent};
 use crate::exec_cache::ExecCache;
-use crate::plugin::{load_plugins, register_plugin, WasmPlugin};
+use crate::plugin::{create_engine, load_plugins, register_plugin, WasmPlugin};
 use anyhow::Result;
 use mlua::{FromLua, Lua, LuaOptions, LuaSerdeExt, SerializeOptions, StdLib};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::{fs, path::PathBuf, time::SystemTime};
 use tracing::instrument;
-use wasmtime::Engine;
 
 mod nerd_font;
 mod style;
@@ -72,7 +71,8 @@ impl ConfigLoader {
         let plugin_dir = get_plugin_dir();
         let default_pwd = std::env::current_dir().unwrap_or_default();
         let exec_cache = Arc::new(create_exec_cache());
-        let plugins = load_plugins(&Engine::default(), &plugin_dir, &default_pwd, &exec_cache)
+        let engine = create_engine()?;
+        let plugins = load_plugins(&engine, &plugin_dir, &default_pwd, &exec_cache)
             .into_iter()
             .map(|p| Rc::new(RefCell::new(p)))
             .collect();

--- a/crates/runtime/src/plugin.rs
+++ b/crates/runtime/src/plugin.rs
@@ -8,9 +8,21 @@ use mlua::{Lua, LuaSerdeExt, Table};
 use serde_json::Value;
 use starship_plugin_core::{from_bitwise, into_bitwise};
 use tracing::instrument;
-use wasmtime::{Caller, Engine, Linker, Memory, Module, Store, TypedFunc};
+use wasmtime::{Cache, Caller, Engine, Linker, Memory, Module, Store, TypedFunc};
 
 use crate::exec_cache::ExecCache;
+
+/// Creates a wasmtime Engine with disk-backed compilation caching.
+///
+/// Compiled machine code is persisted to the platform cache directory
+/// (e.g. `~/Library/Caches/wasmtime` on macOS). The cache key includes
+/// the wasm bytes, engine config, and wasmtime version, so it
+/// automatically invalidates when any of these change.
+pub fn create_engine() -> Result<Engine> {
+    let mut config = wasmtime::Config::new();
+    config.cache(Some(Cache::from_file(None)?));
+    Ok(Engine::new(&config)?)
+}
 
 struct HostState {
     pwd: PathBuf,
@@ -427,9 +439,9 @@ pub mod test_helpers {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use wasmtime::{Engine, Module};
+    use wasmtime::Module;
 
-    use super::WasmPlugin;
+    use super::{create_engine, WasmPlugin};
     use crate::exec_cache::ExecCache;
 
     pub const TEST_HARNESS_WASM: &[u8] = include_bytes!(concat!(
@@ -455,7 +467,7 @@ pub mod test_helpers {
         pub fn from_wasm(bytes: &[u8]) -> Self {
             let dir = tempfile::TempDir::new().expect("tempdir");
             let path = dir.path().to_path_buf();
-            let engine = Engine::default();
+            let engine = create_engine().expect("engine should build");
             let module = Module::new(&engine, bytes).expect("plugin should compile");
             let cache = Arc::new(ExecCache::in_memory());
             let plugin =
@@ -526,9 +538,8 @@ mod tests {
     use std::sync::Arc;
 
     use mlua::{Lua, LuaOptions, StdLib};
-    use wasmtime::Engine;
 
-    use super::load_plugins;
+    use super::{create_engine, load_plugins};
     use crate::exec_cache::ExecCache;
     use crate::plugin_fixture;
 
@@ -568,7 +579,7 @@ mod tests {
     fn load_plugins_empty_dir_returns_empty_vec() {
         let dir = tempfile::tempdir().expect("tempdir");
         let plugin_dir = tempfile::tempdir().expect("plugin dir");
-        let engine = Engine::default();
+        let engine = create_engine().unwrap();
         let cache = Arc::new(ExecCache::in_memory());
         let plugins = load_plugins(&engine, plugin_dir.path(), dir.path(), &cache);
         assert!(plugins.is_empty());


### PR DESCRIPTION
## Summary

- Enable wasmtime's built-in `cache` feature on `starship-runtime` and `starship-bench`
- Add `create_engine()` that configures `Cache::from_file(None)` (platform default cache dir)
- Replace all `Engine::default()` call sites with `create_engine()`

## Why

`plugin_load` benchmarks at 31.1ms — 3.7x over the 8.33ms (120fps) budget. The entire cost is Cranelift recompiling the same WASM bytes from scratch on every `Module::new()` call. With the cache enabled, compiled machine code is persisted to disk and deserialized on subsequent loads, skipping compilation entirely.

## Cache invalidation

The cache key is a SHA-256 hash of wasm bytes + compiler target + engine config + wasmtime version. It's stored under a `modules/wasmtime-<VERSION>/` subdirectory, so a wasmtime upgrade automatically busts it. Writes are atomic (temp file + rename).

## Expected impact

- **First load** (cold cache): ~31ms (unchanged)
- **Subsequent loads** (cache hit): <1ms
- **Production**: Daemon restart skips compilation for unchanged plugins